### PR TITLE
Stabilize Google JWK URI retrieval tests

### DIFF
--- a/back/appointment-service/internal/auth/oidc/google/jwks_uri.go
+++ b/back/appointment-service/internal/auth/oidc/google/jwks_uri.go
@@ -10,19 +10,27 @@ import (
 const GoogleOpenIDDoc = "https://accounts.google.com/.well-known/openid-configuration"
 
 func FetchGoogleJWKsUri(ctx context.Context) (string, error) {
+	return fetchJWKsURI(ctx, GoogleOpenIDDoc, http.DefaultClient)
+}
+
+func fetchJWKsURI(ctx context.Context, openIDDocURL string, client *http.Client) (string, error) {
 	var cfg struct {
 		JwksURI string `json:"jwks_uri"`
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, GoogleOpenIDDoc, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, openIDDocURL, nil)
 	if err != nil {
 		return "", err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("[FetchGoogleJWKsUri] http request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("[FetchGoogleJWKsUri] unexpected status code: %d", resp.StatusCode)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
 		return "", fmt.Errorf("[FetchGoogleJWKsUri] http body decoding: %w", err)

--- a/back/appointment-service/internal/auth/oidc/google/jwks_uri_test.go
+++ b/back/appointment-service/internal/auth/oidc/google/jwks_uri_test.go
@@ -2,14 +2,34 @@ package google
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFetchGoogleJWKsUri(t *testing.T) {
 	const expected = "https://www.googleapis.com/oauth2/v3/certs"
-	uri, err := FetchGoogleJWKsUri(context.Background())
-	assert.NoError(t, err)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jwks_uri":"` + expected + `"}`))
+	}))
+	defer ts.Close()
+
+	uri, err := fetchJWKsURI(context.Background(), ts.URL, ts.Client())
+	require.NoError(t, err)
 	assert.Equal(t, expected, uri)
+}
+
+func TestFetchGoogleJWKsUri_ErrorStatus(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+
+	_, err := fetchJWKsURI(context.Background(), ts.URL, ts.Client())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected status code")
 }


### PR DESCRIPTION
### Motivation
- Remove a network-dependent, flaky unit test that failed when contacting Google's OpenID configuration and make the JWKs URI retrieval logic testable.
- Ensure callers get a clear error when the OpenID configuration endpoint returns a non-200 status instead of attempting to decode an unexpected response.

### Description
- Refactored `FetchGoogleJWKsUri` to delegate to an internal helper `fetchJWKsURI(ctx, openIDDocURL, client)` so an alternate endpoint and HTTP client can be injected for tests.
- Replaced direct use of `http.DefaultClient` with the injected `client` and changed the request URL to the injected `openIDDocURL`.
- Added an explicit HTTP status code check that returns an error when the response status is not `200 OK`.
- Rewrote the test to use `httptest.NewServer` and `ts.Client()` so the success case is mocked and added `TestFetchGoogleJWKsUri_ErrorStatus` to verify non-200 behavior.

### Testing
- Ran `go -C back/appointment-service test ./internal/auth/oidc/google ./internal/auth/oidc` and the targeted packages passed.
- Ran `make test` (which runs `go -C back/appointment-service test ./...`) and the full service test suite passed.
- Confirmed the previous failure of `TestFetchGoogleJWKsUri` due to external network `Forbidden` was resolved by the mocked tests and new status-code handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07338e7b8832b974b19d5bdef016a)