### PR TITLE
Make Google JWK URI fetching testable and handle non-200 OpenID responses

### DIFF
--- a/back/appointment-service/internal/auth/oidc/google/jwks_uri.go
+++ b/back/appointment-service/internal/auth/oidc/google/jwks_uri.go
@@ -10,19 +10,27 @@ import (
 const GoogleOpenIDDoc = "https://accounts.google.com/.well-known/openid-configuration"
 
 func FetchGoogleJWKsUri(ctx context.Context) (string, error) {
+	return fetchJWKsURI(ctx, http.DefaultClient, GoogleOpenIDDoc)
+}
+
+func fetchJWKsURI(ctx context.Context, httpClient *http.Client, openIDDocURL string) (string, error) {
 	var cfg struct {
 		JwksURI string `json:"jwks_uri"`
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, GoogleOpenIDDoc, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, openIDDocURL, nil)
 	if err != nil {
 		return "", err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("[FetchGoogleJWKsUri] http request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("[FetchGoogleJWKsUri] unexpected status code: %d", resp.StatusCode)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&cfg); err != nil {
 		return "", fmt.Errorf("[FetchGoogleJWKsUri] http body decoding: %w", err)

--- a/back/appointment-service/internal/auth/oidc/google/jwks_uri_test.go
+++ b/back/appointment-service/internal/auth/oidc/google/jwks_uri_test.go
@@ -2,14 +2,39 @@ package google
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFetchGoogleJWKsUri(t *testing.T) {
-	const expected = "https://www.googleapis.com/oauth2/v3/certs"
-	uri, err := FetchGoogleJWKsUri(context.Background())
-	assert.NoError(t, err)
-	assert.Equal(t, expected, uri)
+func TestFetchJWKsURI(t *testing.T) {
+	t.Run("fetches jwks uri from openid document", func(t *testing.T) {
+		const expected = "https://www.googleapis.com/oauth2/v3/certs"
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			_, err := fmt.Fprintf(w, `{"jwks_uri":"%s"}`, expected)
+			require.NoError(t, err)
+		}))
+		defer s.Close()
+
+		actual, err := fetchJWKsURI(context.Background(), s.Client(), s.URL)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("returns explicit error on non-200 response", func(t *testing.T) {
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "upstream error", http.StatusInternalServerError)
+		}))
+		defer s.Close()
+
+		_, err := fetchJWKsURI(context.Background(), s.Client(), s.URL)
+		require.Error(t, err)
+		assert.EqualError(t, err, "[FetchGoogleJWKsUri] unexpected status code: 500")
+	})
 }


### PR DESCRIPTION
### Motivation

- Eliminate a flaky network-dependent unit test that contacted Google's OpenID configuration and make JWKs URI retrieval deterministic and testable.
- Ensure callers receive a clear error when the OpenID configuration endpoint returns a non-200 status instead of attempting to decode an unexpected response.

### Description

- Refactored `FetchGoogleJWKsUri` to delegate to an internal helper `fetchJWKsURI(ctx, httpClient, openIDDocURL)` that accepts an `*http.Client` and an OpenID document URL for easier testing; changed implementation in `back/appointment-service/internal/auth/oidc/google/jwks_uri.go`.
- Added explicit HTTP status validation so non-200 responses return an error `"[FetchGoogleJWKsUri] unexpected status code: <code>"` before JSON decoding.
- Replaced the flaky live-network unit test with deterministic `httptest`-based tests in `back/appointment-service/internal/auth/oidc/google/jwks_uri_test.go` covering both successful JWKs URI extraction and non-200 error behavior.
- Kept the public API (`FetchGoogleJWKsUri`) intact while enabling dependency injection for testability.

### Testing

- Ran `go test ./internal/auth/oidc/google` and it passed (`ok`).
- Ran `go test ./internal/auth/oidc/...` and the package tests passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b096688b24832b9e722891f777493d)