### PR TITLE
Add English and Kazakh date localization primitives

### DIFF
--- a/back/appointment-service/internal/bot/i18n/date/en.go
+++ b/back/appointment-service/internal/bot/i18n/date/en.go
@@ -1,0 +1,41 @@
+package date
+
+import (
+	"time"
+)
+
+var monthsShortEn = map[time.Month]string{
+	time.January:   "Jan",
+	time.February:  "Feb",
+	time.March:     "Mar",
+	time.April:     "Apr",
+	time.May:       "May",
+	time.June:      "Jun",
+	time.July:      "Jul",
+	time.August:    "Aug",
+	time.September: "Sep",
+	time.October:   "Oct",
+	time.November:  "Nov",
+	time.December:  "Dec",
+}
+
+var weekdaysShortEn = map[time.Weekday]string{
+	time.Monday:    "Mon",
+	time.Tuesday:   "Tue",
+	time.Wednesday: "Wed",
+	time.Thursday:  "Thu",
+	time.Friday:    "Fri",
+	time.Saturday:  "Sat",
+	time.Sunday:    "Sun",
+}
+
+type DateFormatEn struct {
+}
+
+func (DateFormatEn) MonthShort(m time.Month) string {
+	return monthsShortEn[m]
+}
+
+func (DateFormatEn) WeekDayShort(d time.Weekday) string {
+	return weekdaysShortEn[d]
+}

--- a/back/appointment-service/internal/bot/i18n/date/kz.go
+++ b/back/appointment-service/internal/bot/i18n/date/kz.go
@@ -1,0 +1,41 @@
+package date
+
+import (
+	"time"
+)
+
+var monthsShortKz = map[time.Month]string{
+	time.January:   "Қаң",
+	time.February:  "Ақп",
+	time.March:     "Нау",
+	time.April:     "Сәу",
+	time.May:       "Мам",
+	time.June:      "Мау",
+	time.July:      "Шіл",
+	time.August:    "Там",
+	time.September: "Қыр",
+	time.October:   "Қаз",
+	time.November:  "Қар",
+	time.December:  "Жел",
+}
+
+var weekdaysShortKz = map[time.Weekday]string{
+	time.Monday:    "Дс",
+	time.Tuesday:   "Сс",
+	time.Wednesday: "Ср",
+	time.Thursday:  "Бс",
+	time.Friday:    "Жм",
+	time.Saturday:  "Сб",
+	time.Sunday:    "Жс",
+}
+
+type DateFormatKz struct {
+}
+
+func (DateFormatKz) MonthShort(m time.Month) string {
+	return monthsShortKz[m]
+}
+
+func (DateFormatKz) WeekDayShort(d time.Weekday) string {
+	return weekdaysShortKz[d]
+}


### PR DESCRIPTION
### Motivation
- Provide English and Kazakh short month and weekday names to support multi-language date formatting consistent with the existing Russian implementation.

### Description
- Added `back/appointment-service/internal/bot/i18n/date/en.go` which defines short month and weekday maps and a `DateFormatEn` type implementing `MonthShort` and `WeekDayShort`.
- Added `back/appointment-service/internal/bot/i18n/date/kz.go` which defines short month and weekday maps and a `DateFormatKz` type implementing `MonthShort` and `WeekDayShort`, matching the `DateFormatRu` API.

### Testing
- Ran `go test ./back/appointment-service/internal/bot/i18n/date` from the repository root which failed due to the repository not being a Go module (`go mod init` required). 
- Ran `go test ./internal/bot/i18n/date` from `back/appointment-service` which built the package successfully and reported `[no test files]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb63d0e20832baebc495af7ee86f4)