### PR TITLE
Fix webapp slot availability check to use slot start time

### DIFF
--- a/back/appointment-service/webapp/app.js
+++ b/back/appointment-service/webapp/app.js
@@ -160,8 +160,7 @@
     const now = Date.now();
     for (const slot of state.daySlots) {
       const start = new Date(slot.tp_start);
-      const end = new Date(start.getTime() + slot.len * 60000);
-      const isBusy = end.getTime() < now;
+      const isBusy = start.getTime() < now;
       const btn = document.createElement('button');
       btn.className = 'slot-btn';
       btn.disabled = isBusy;


### PR DESCRIPTION
### Motivation
- The backend rejects bookings whose `tp_start` is before the current time (`TpStart.Before(time.Now())`), while the webapp previously marked slots busy only when the *end* time was past, creating a predictable client/server mismatch.

### Description
- Updated `renderDaySlots` in `back/appointment-service/webapp/app.js` to mark a slot unavailable based on its start time by using `isBusy = start.getTime() < now`, removing the previous end-time based gate.

### Testing
- Ran `node --check back/appointment-service/webapp/app.js` to verify the script syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfc61534c0832ba9838a5f2296ac99)