### PR TITLE
Closes #53. Add GET /customer/appointments endpoint and storage query for customer appointments

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -269,6 +269,45 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /customer/appointments:
+    get:
+      tags: [Time slots]
+      summary: Get customer appointments for the authenticated Telegram Mini App user
+      security:
+        - TelegramMiniAppAuth: []
+      parameters:
+        - in: header
+          name: X-Client-ID
+          required: true
+          schema:
+            type: string
+          description: Telegram bot identifier stored as `bot_id` in `user_bots`, used for signature verification and business lookup.
+        - in: query
+          name: date_start
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Interval start for filtering appointments. Defaults to current time when omitted.
+        - in: query
+          name: date_end
+          required: false
+          schema:
+            type: string
+            format: date-time
+          description: Optional interval end for filtering appointments.
+      responses:
+        '200':
+          description: Customer appointments in requested interval
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailableSlots'
+        '400':
+          description: Invalid initData or invalid query parameters
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /slots:
     post:
       tags: [Time slots]

--- a/back/appointment-service/api/api_time_slots.go
+++ b/back/appointment-service/api/api_time_slots.go
@@ -3,6 +3,7 @@ package api
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -56,6 +57,19 @@ func getTimeFromURL(key string, v url.Values) (time.Time, error) {
 	return dt, nil
 }
 
+func getTimeFromURLOptional(key string, v url.Values) (time.Time, error) {
+	dtStr := v.Get(key)
+	if dtStr == "" {
+		return time.Time{}, fmt.Errorf("%s: %w", key, common.ErrNotFound)
+	}
+
+	dt, err := parseTime(dtStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return dt, nil
+}
+
 func getSlotChunkFromURL(v url.Values, defaults slotsdb.BusinessSlotSettings) (time.Duration, error) {
 	chunkMinutesStr := v.Get("chunk_minutes")
 	if chunkMinutesStr == "" {
@@ -96,6 +110,68 @@ func (a *api) SlotsBusinessWebAppGetFunc(au AddSlotsAuth) http.HandlerFunc {
 		}
 
 		a.getSlotsByBusinessID(w, r, string(authResult.Business))
+	}
+}
+
+func (a *api) CustomerAppointmentsGetFunc(au AddSlotsAuth) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+
+		authResult, err := au.Authorization(r)
+		if err != nil {
+			slog.WarnContext(r.Context(), "[CustomerAppointmentsGet]", "err", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		dateStart, err := getTimeFromURLOptional("date_start", r.URL.Query())
+		if err != nil {
+			if errors.Is(err, common.ErrNotFound) {
+				dateStart = time.Now()
+			} else {
+				slog.WarnContext(r.Context(), "[CustomerAppointmentsGet]", "err", err.Error())
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		}
+		if dateStart.IsZero() {
+			dateStart = time.Now()
+		}
+
+		dateEnd, err := getTimeFromURLOptional("date_end", r.URL.Query())
+		if err != nil && !errors.Is(err, common.ErrNotFound) {
+			slog.WarnContext(r.Context(), "[CustomerAppointmentsGet]", "err", err.Error())
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if !dateEnd.IsZero() && dateEnd.Before(dateStart) {
+			slog.WarnContext(r.Context(), "[CustomerAppointmentsGet] date_end is before date_start")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		between := common.Interval{Start: dateStart, End: dateEnd}
+		appointments, err := a.storages.TimeSlots.GetCustomerAppointmentsInRange(authResult.Business, authResult.Customer, between)
+		if err != nil {
+			slog.WarnContext(r.Context(), "[CustomerAppointmentsGet]", "err", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var response swagger.AvailableSlots
+		response.QueryId = r.Context().Value(RequestIdKey{}).(string)
+		for _, appt := range appointments {
+			response.Slots = append(response.Slots, swagger.Slot{
+				TpStart: appt.Start,
+				Len:     int32(appt.End.Sub(appt.Start).Minutes()),
+			})
+		}
+
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			slog.WarnContext(r.Context(), "[CustomerAppointmentsGet]", "err", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/back/appointment-service/api/routers.go
+++ b/back/appointment-service/api/routers.go
@@ -179,6 +179,15 @@ func (a *api) addTimeSlotsHandlers(r *mux.Router) {
 			}),
 		},
 		Route{
+			"CustomerAppointmentsGetFromWebApp",
+			"GET",
+			"/customer/appointments",
+			a.CustomerAppointmentsGetFunc(AddSlotsAuthTgWebApp{
+				BotsStorage: a.storages.Bots,
+				Validator:   auth.NewTelegramWebAppInitDataValidator(),
+			}),
+		},
+		Route{
 			"SlotsBusinessIdPost",
 			"POST",
 			"/slots",

--- a/back/appointment-service/internal/dbase/backend/slots/appointments.go
+++ b/back/appointment-service/internal/dbase/backend/slots/appointments.go
@@ -212,6 +212,53 @@ func (db *TimeSlotsStorage) GetBusySlotsInRange(business_id common.ID, between c
 	return slotsOut, nil
 }
 
+// GetCustomerAppointmentsInRange returns customer's appointments for the given business
+// that overlap the requested interval.
+//
+// Acceptable arguments:
+//   - businessID and customerID must identify the exact business/customer pair to filter by.
+//   - between.Start is required and used as the lower bound.
+//   - between.End is optional:
+//   - if between.End.IsZero() then all appointments with date_end >= between.Start are returned
+//     (including appointments that started before between.Start but are still in progress).
+//   - if between.End is set then appointments are returned only when they overlap
+//     [between.Start, between.End], i.e. date_end >= between.Start AND date_start <= between.End.
+//
+// Returned appointments are ordered by date_start ascending.
+func (db *TimeSlotsStorage) GetCustomerAppointmentsInRange(businessID common.ID, customerID common.ID, between common.Interval) ([]common.BusySlot, error) {
+	var (
+		dbSlots []dbBusySlot
+		err     error
+	)
+
+	if between.End.IsZero() {
+		err = db.Select(
+			&dbSlots,
+			`SELECT * FROM appointments
+			 WHERE business_id = $1 AND customer_id = $2 AND date_end >= $3
+			 ORDER BY date_start`,
+			string(businessID), string(customerID), between.Start.Unix(),
+		)
+	} else {
+		err = db.Select(
+			&dbSlots,
+			`SELECT * FROM appointments
+			 WHERE business_id = $1 AND customer_id = $2 AND date_end >= $3 AND date_start <= $4
+			 ORDER BY date_start`,
+			string(businessID), string(customerID), between.Start.Unix(), between.End.Unix(),
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	slotsOut := make([]common.BusySlot, 0, len(dbSlots))
+	for _, dbSlot := range dbSlots {
+		slotsOut = append(slotsOut, dbSlot.ToSlot())
+	}
+	return slotsOut, nil
+}
+
 func (db *TimeSlotsStorage) DeleteSlots(business_id common.ID, customerID common.ID, start time.Time, end time.Time) error {
 	_, err := db.Exec("DELETE FROM appointments WHERE business_id = $1 AND customer_id = $2 AND date_start BETWEEN $3 AND $4",
 		business_id, customerID, start.Unix(), end.Unix())

--- a/back/appointment-service/internal/dbase/backend/slots/storage_test.go
+++ b/back/appointment-service/internal/dbase/backend/slots/storage_test.go
@@ -248,3 +248,105 @@ func TestBusinessSlotSettingsValidation(t *testing.T) {
 		t.Fatal("expected validation error on read")
 	}
 }
+
+func TestGetCustomerAppointmentsInRange(t *testing.T) {
+	storage := TimeSlotsStorage{test.InitTmpDB(t)}
+	defer storage.Close()
+
+	base := time.Now().Truncate(time.Minute)
+	slotInProgress := common.Interval{Start: base.Add(-30 * time.Minute), End: base.Add(30 * time.Minute)}
+	slotAfterStart := common.Interval{Start: base.Add(60 * time.Minute), End: base.Add(90 * time.Minute)}
+	slotAfterAllRanges := common.Interval{Start: base.Add(180 * time.Minute), End: base.Add(210 * time.Minute)}
+
+	err := storage.AddSlots(AddSlotsData{
+		Business: "b1",
+		Customer: "c1",
+		Slots: common.Intervals{
+			slotInProgress,
+			slotAfterStart,
+			slotAfterAllRanges,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = storage.AddSlots(AddSlotsData{
+		Business: "b1",
+		Customer: "c2",
+		Slots: common.Intervals{
+			{Start: base.Add(120 * time.Minute), End: base.Add(150 * time.Minute)},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type tc struct {
+		name       string
+		between    common.Interval
+		want       common.Intervals
+		wantCustID common.ID
+	}
+
+	tests := []tc{
+		{
+			name:       "open interval from now includes in-progress and future slots",
+			between:    common.Interval{Start: base},
+			want:       common.Intervals{slotInProgress, slotAfterStart, slotAfterAllRanges},
+			wantCustID: "c1",
+		},
+		{
+			name:       "bounded interval intersects only first slot",
+			between:    common.Interval{Start: base, End: base.Add(45 * time.Minute)},
+			want:       common.Intervals{slotInProgress},
+			wantCustID: "c1",
+		},
+		{
+			name:       "bounded interval intersects middle slot only",
+			between:    common.Interval{Start: base.Add(45 * time.Minute), End: base.Add(100 * time.Minute)},
+			want:       common.Intervals{slotAfterStart},
+			wantCustID: "c1",
+		},
+		{
+			name:       "bounded interval with no overlap returns empty",
+			between:    common.Interval{Start: base.Add(100 * time.Minute), End: base.Add(120 * time.Minute)},
+			want:       common.Intervals{},
+			wantCustID: "c1",
+		},
+		{
+			name:       "different customer is filtered out",
+			between:    common.Interval{Start: base},
+			want:       common.Intervals{},
+			wantCustID: "unknown-customer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := storage.GetCustomerAppointmentsInRange("b1", tt.wantCustID, tt.between)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("unexpected slots count: got %d want %d", len(got), len(tt.want))
+			}
+
+			for i := range tt.want {
+				if got[i].Customer != tt.wantCustID {
+					t.Fatalf("unexpected customer id in result: got %q want %q", got[i].Customer, tt.wantCustID)
+				}
+				if got[i].Start != tt.want[i].Start || got[i].End != tt.want[i].End {
+					t.Fatalf(
+						"unexpected slot[%d]: got [%s - %s], want [%s - %s]",
+						i,
+						got[i].Start.Format(time.RFC3339),
+						got[i].End.Format(time.RFC3339),
+						tt.want[i].Start.Format(time.RFC3339),
+						tt.want[i].End.Format(time.RFC3339),
+					)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Provide Telegram Mini App users an endpoint to retrieve their appointments filtered by an optional time interval. 
- Support open-ended queries where `date_end` can be omitted to include in-progress and future appointments. 

### Description

- Added OpenAPI spec for `GET /customer/appointments` with `date_start` and optional `date_end` query parameters and `X-Client-ID` header. 
- Implemented `CustomerAppointmentsGetFunc` handler and `getTimeFromURLOptional` helper to parse optional date params and default `date_start` to `time.Now()` when absent. 
- Registered the route in `routers.go` using `AddSlotsAuthTgWebApp` authentication. 
- Added `GetCustomerAppointmentsInRange` to the slots storage which queries appointments by `business_id` and `customer_id`, supports an optional `between.End`, and returns results ordered by `date_start`. 
- Added unit test `TestGetCustomerAppointmentsInRange` to validate open and bounded interval behavior and customer filtering. 

### Testing

- Ran the package unit tests including `TestGetCustomerAppointmentsInRange` in `internal/dbase/backend/slots`, and the test passed. 
- No other automated test failures were observed when running the backend package tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d267e695e4832b81dbbd29e38e160f)