### PR TITLE
Closes #51. Add bot 'appointments' command and HTTP client for customer appointments

### DIFF
--- a/back/appointment-service/api/routers.go
+++ b/back/appointment-service/api/routers.go
@@ -188,6 +188,12 @@ func (a *api) addTimeSlotsHandlers(r *mux.Router) {
 			}),
 		},
 		Route{
+			"CustomerAppointmentsGetFromBot",
+			"GET",
+			"/customer/appointments/bt",
+			AuthHandler(botAuthMethod(&bs), a.CustomerAppointmentsGetFunc(AddSlotsAuthFromUrl{}), http.HandlerFunc(LoginRequired)),
+		},
+		Route{
 			"SlotsBusinessIdPost",
 			"POST",
 			"/slots",

--- a/back/appointment-service/internal/bot/command/default.go
+++ b/back/appointment-service/internal/bot/command/default.go
@@ -11,7 +11,8 @@ func NewDefaultMainMenu(chat chat.Chat, l *messages.Localization, connection *bo
 	if err != nil {
 		return nil, err
 	}
-	return newMainMenu(md, newDefaultSlotSelectionCommand(md, connection)), nil
+	appointments := &HttpAppointment{Connection: connection}
+	return newMainMenu(md, newDefaultSlotSelectionCommand(md, connection), appointments), nil
 }
 
 func newDefaultSlotSelectionCommand(md *MenuDeps, connection *bot.SchedulerConnection) *SlotSelectionCommand {

--- a/back/appointment-service/internal/bot/command/dialogs_storage.go
+++ b/back/appointment-service/internal/bot/command/dialogs_storage.go
@@ -42,8 +42,9 @@ func (ds *DialogsStorage) GetOrCreateMenu(ca Customer, ch chat.ChatID) *MainMenu
 	dialog = ds.dialogs[ca]
 	if dialog == nil || dialog.ChatID != ch {
 		clone := ds.depsProto.Clone()
+		appointments := &HttpAppointment{Connection: ds.connection}
 		dialog = &DialogValue{
-			Menu:   newMainMenu(clone, newDefaultSlotSelectionCommand(clone, ds.connection)),
+			Menu:   newMainMenu(clone, newDefaultSlotSelectionCommand(clone, ds.connection), appointments),
 			ChatID: ch,
 		}
 		ds.dialogs[ca] = dialog

--- a/back/appointment-service/internal/bot/command/http_appointment.go
+++ b/back/appointment-service/internal/bot/command/http_appointment.go
@@ -17,6 +17,10 @@ type HttpAppointment struct {
 	Connection *bot.SchedulerConnection
 }
 
+type AppointmentsProvider interface {
+	CustomerAppointmentsInRange(ctx context.Context, customer common.ID, interval common.Interval) ([]common.Slot, error)
+}
+
 func (a *HttpAppointment) AddSlots(ctx context.Context, customer common.ID, slots []common.Slot) error {
 	u, err := url.JoinPath(a.Connection.URL, "slots/bt")
 	if err != nil {
@@ -96,6 +100,56 @@ func (p *HttpAppointment) AvailableSlotsInRange(ctx context.Context, interval co
 		tmp.Start = slot.TpStart
 		tmp.Dur = time.Minute * time.Duration(slot.Len)
 		out = append(out, tmp)
+	}
+	return out, nil
+}
+
+func (p *HttpAppointment) CustomerAppointmentsInRange(ctx context.Context, customer common.ID, interval common.Interval) ([]common.Slot, error) {
+	u, err := url.JoinPath(p.Connection.URL, "customer/appointments/bt")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-Client-ID", p.Connection.ClientId)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", p.Connection.Token))
+
+	v := req.URL.Query()
+	v.Set("customer_id", string(customer))
+	if !interval.Start.IsZero() {
+		v.Set("date_start", interval.Start.Format(time.RFC3339))
+	}
+	if !interval.End.IsZero() {
+		v.Set("date_end", interval.End.Format(time.RFC3339))
+	}
+	req.URL.RawQuery = v.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkStatusCode(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var slots swagger.AvailableSlots
+	err = json.NewDecoder(resp.Body).Decode(&slots)
+	if err != nil {
+		return nil, fmt.Errorf("http: unexpected response (%s)", resp.Status)
+	}
+
+	out := make([]common.Slot, 0, len(slots.Slots))
+	for _, slot := range slots.Slots {
+		out = append(out, common.Slot{
+			Start: slot.TpStart,
+			Dur:   time.Minute * time.Duration(slot.Len),
+		})
 	}
 	return out, nil
 }

--- a/back/appointment-service/internal/bot/command/main_menu.go
+++ b/back/appointment-service/internal/bot/command/main_menu.go
@@ -1,13 +1,16 @@
 package command
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	common "scheduler/appointment-service/internal"
 	"scheduler/appointment-service/internal/bot/chat"
 	"scheduler/appointment-service/internal/bot/i18n/messages"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 )
@@ -67,6 +70,7 @@ func NewMenuDeps(ch chat.Chat, loc *messages.Localization) (*MenuDeps, error) {
 func commandMap(l *i18n.Localizer) (messages.MessageMap, error) {
 	return messages.LocalizedMessageMap(l,
 		messages.BookSlot,
+		messages.Appointments,
 		messages.Help,
 		messages.NextWeek,
 		messages.ThisWeek,
@@ -78,6 +82,7 @@ func commandMap(l *i18n.Localizer) (messages.MessageMap, error) {
 type MainMenu struct {
 	menuDeps     *MenuDeps
 	slotCommands *SlotSelectionCommand
+	appointments AppointmentsProvider
 	state        mainMenuState
 }
 
@@ -112,6 +117,8 @@ func (menu *MainMenu) Process(r *Request) error {
 				return err
 			}
 			menu.state = menuSlotSelection
+		} else if c == messages.Appointments {
+			return menu.ShowAppointments(r.Ctx, r.ChatContext, common.ID(r.Customer), time.Now())
 		} else if c == messages.Help || r.Text == "/help" {
 			return menu.ShowHelp(r.ChatContext)
 		} else {
@@ -156,7 +163,7 @@ func (menu *MainMenu) showMessageForce(c *chat.ChatContext, msg *i18n.Message) e
 func (menu *MainMenu) BackToStart(c *chat.ChatContext) error {
 	menu.state = menuStart
 	menu.slotCommands.Cancel()
-	options := []*i18n.Message{messages.BookSlot, messages.Help, messages.Cancel}
+	options := []*i18n.Message{messages.BookSlot, messages.Appointments, messages.Help, messages.Cancel}
 	err := menu.menuDeps.Chat().ShowMenuMessages(c, messages.CommandRequestMessage, options)
 	if err != nil {
 		slog.ErrorContext(c.Ctx, "mainMenu.BackToStart", "err", err.Error())
@@ -165,10 +172,54 @@ func (menu *MainMenu) BackToStart(c *chat.ChatContext) error {
 	return nil
 }
 
-func newMainMenu(md *MenuDeps, slotCommands *SlotSelectionCommand) *MainMenu {
+func (menu *MainMenu) ShowAppointments(ctx context.Context, c *chat.ChatContext, customer common.ID, now time.Time) error {
+	appointments, err := menu.appointments.CustomerAppointmentsInRange(ctx, customer, common.Interval{Start: now})
+	if err != nil {
+		return err
+	}
+
+	msg := formatAppointmentsMessage(menu.menuDeps.Loc.Localizer(), appointments)
+	return menu.menuDeps.Chat().PrintMessage(c, &i18n.Message{ID: "AppointmentsList", Other: msg})
+}
+
+func formatAppointmentsMessage(l *i18n.Localizer, appointments []common.Slot) string {
+	header, err := l.LocalizeMessage(messages.AppointmentsListHeader)
+	if err != nil {
+		header = messages.AppointmentsListHeader.Other
+	}
+	noUpcoming, err := l.LocalizeMessage(messages.NoUpcomingAppointments)
+	if err != nil {
+		noUpcoming = messages.NoUpcomingAppointments.Other
+	}
+
+	if len(appointments) == 0 {
+		return noUpcoming
+	}
+
+	apptSorted := make([]common.Slot, len(appointments))
+	copy(apptSorted, appointments)
+	sort.Slice(apptSorted, func(i, j int) bool {
+		return apptSorted[i].Start.Before(apptSorted[j].Start)
+	})
+
+	var b strings.Builder
+	b.WriteString(header)
+	b.WriteString("\n")
+	for _, appt := range apptSorted {
+		b.WriteString("- ")
+		b.WriteString(appt.Start.Format(time.DateTime))
+		b.WriteString(" (")
+		b.WriteString(appt.Dur.String())
+		b.WriteString(")\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func newMainMenu(md *MenuDeps, slotCommands *SlotSelectionCommand, appointments AppointmentsProvider) *MainMenu {
 	return &MainMenu{
 		menuDeps:     md,
 		slotCommands: slotCommands,
+		appointments: appointments,
 		state:        menuStart,
 	}
 }

--- a/back/appointment-service/internal/bot/i18n/messages/messages.go
+++ b/back/appointment-service/internal/bot/i18n/messages/messages.go
@@ -42,6 +42,21 @@ var BookSlot = &i18n.Message{
 	Other: "book a slot",
 }
 
+var Appointments = &i18n.Message{
+	ID:    "Appointments",
+	Other: "appointments",
+}
+
+var AppointmentsListHeader = &i18n.Message{
+	ID:    "AppointmentsListHeader",
+	Other: "Your upcoming appointments:",
+}
+
+var NoUpcomingAppointments = &i18n.Message{
+	ID:    "NoUpcomingAppointments",
+	Other: "No upcoming appointments",
+}
+
 var WrongUserInput = &i18n.Message{
 	ID:    "WrongUserInput",
 	Other: "Input text is unexpected",
@@ -62,6 +77,7 @@ var HelpMessage = &i18n.Message{
 	Other: `Available commands:
 "help" - Show this help message
 "book a slot"   - Book a slot for an appointment
+"appointments" - Show your upcoming appointments
 "cancel" - Cancel current operation or booking
 Use special button or type it
 `,


### PR DESCRIPTION
### Motivation

- Provide bot users with a way to view their upcoming appointments from the service via a new "appointments" command in the main menu. 
- Expose and consume a bot-authenticated customer appointments HTTP endpoint to fetch appointments for a customer.
- Integrate the appointments flow into existing menu/dialog infrastructure so it can be used from the bot UI.

### Description

- Added a new authenticated route for bot requests `GET /customer/appointments/bt` in `api/routers.go` and wired it to use bot auth handling.
- Implemented `HttpAppointment.CustomerAppointmentsInRange` in `internal/bot/command/http_appointment.go` to call `customer/appointments/bt`, parse the response into `[]common.Slot`, and added the `AppointmentsProvider` interface.
- Extended bot menu and dialog code to support appointments by adding `Appointments` i18n messages, a new menu option, and a `ShowAppointments` handler in `internal/bot/command/main_menu.go`; introduced `formatAppointmentsMessage` to localize and format the appointment list.
- Wired `HttpAppointment` into constructors (`NewDefaultMainMenu`, `NewDialogStorage`) and updated `newMainMenu` signature to accept an `AppointmentsProvider` so menus use the HTTP client to retrieve appointments.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c27660b4832b90323b8cb8560862)