### PR TITLE
Add per-user language and timezone settings with Settings menu and default config

### DIFF
--- a/back/appointment-service/cmd/bot/bot.go
+++ b/back/appointment-service/cmd/bot/bot.go
@@ -53,8 +53,14 @@ func main() {
 	bundle.LoadMessageFile(langFilePrefix + ".en.toml")
 
 	localization := messages.NewLocalization(bundle, "ru")
+	defaultLoc, err := time.LoadLocation(cfg.DefaultUserSettings.TimeZone)
+	if err != nil {
+		slog.Error("[time.LoadLocation]", "err", err.Error(), "time_zone", cfg.DefaultUserSettings.TimeZone)
+		log.Fatal(err)
+	}
+	localization.SetLanguage(cfg.DefaultUserSettings.Language)
 	cha := &telegram.Tg{Bot: b}
-	dialogStorage, err := command.NewDialogStorage(cha, localization, &cfg.SchedulerAPI)
+	dialogStorage, err := command.NewDialogStorage(cha, localization, defaultLoc, &cfg.SchedulerAPI)
 	if err != nil {
 		slog.Error("[NewDialogStorage]", "err", err.Error())
 		log.Fatal(err)
@@ -80,7 +86,7 @@ func makeHandler(ds *command.DialogsStorage) bot.HandlerFunc {
 		}
 
 		customer := command.Customer(fmt.Sprint(update.Message.From.ID))
-		menu := ds.GetOrCreateMenu(customer, update.Message.Chat.ID)
+		menu := ds.GetOrCreateMenu(customer, update.Message.Chat.ID, telegramLanguage(update.Message.From), nil)
 		if menu == nil {
 			slog.Error("[bot.HandlerFunc]", "err", "unexpected: menu == nil")
 			return
@@ -104,6 +110,16 @@ func makeHandler(ds *command.DialogsStorage) bot.HandlerFunc {
 			slog.Error("[Handler:menu.Process]", "err", err.Error())
 		}
 	}
+}
+
+func telegramLanguage(user *models.User) string {
+	if user == nil || user.LanguageCode == "" {
+		return ""
+	}
+	if len(user.LanguageCode) < 2 {
+		return user.LanguageCode
+	}
+	return user.LanguageCode[:2]
 }
 
 func makeOptionsCallbackHandler(ds *command.DialogsStorage) bot.HandlerFunc {

--- a/back/appointment-service/cmd/bot/config.go
+++ b/back/appointment-service/cmd/bot/config.go
@@ -8,9 +8,10 @@ import (
 )
 
 type BotConfig struct {
-	BotAPIConnection string                  `cfg:"bot_api_connection"`
-	LogLevel         slog.Level              `cfg:"log_level"`
-	SchedulerAPI     bot.SchedulerConnection `cfg:"scheduler"`
+	BotAPIConnection    string                  `cfg:"bot_api_connection"`
+	LogLevel            slog.Level              `cfg:"log_level"`
+	SchedulerAPI        bot.SchedulerConnection `cfg:"scheduler"`
+	DefaultUserSettings bot.DefaultUserSettings `cfg:"default_user"`
 }
 
 func (c *BotConfig) Validate() error {
@@ -22,6 +23,9 @@ func (c *BotConfig) Validate() error {
 	}
 	if c.SchedulerAPI.Token == "" {
 		return errors.New("scheduler_api token is not set")
+	}
+	if err := c.DefaultUserSettings.Validate(); err != nil {
+		return err
 	}
 
 	return c.SchedulerAPI.Validate()

--- a/back/appointment-service/cmd/bot/config.go
+++ b/back/appointment-service/cmd/bot/config.go
@@ -11,7 +11,7 @@ type BotConfig struct {
 	BotAPIConnection    string                  `cfg:"bot_api_connection"`
 	LogLevel            slog.Level              `cfg:"log_level"`
 	SchedulerAPI        bot.SchedulerConnection `cfg:"scheduler"`
-	DefaultUserSettings bot.DefaultUserSettings `cfg:"default_user"`
+	DefaultUserSettings bot.DefaultUserSettings `cfg:"def_user_settings"`
 }
 
 func (c *BotConfig) Validate() error {

--- a/back/appointment-service/internal/bot/command/chat_adapter.go
+++ b/back/appointment-service/internal/bot/command/chat_adapter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	common "scheduler/appointment-service/internal"
+	"scheduler/appointment-service/internal/bot"
 	"scheduler/appointment-service/internal/bot/chat"
 	"scheduler/appointment-service/internal/bot/i18n/messages"
 	"slices"
@@ -17,13 +18,13 @@ import (
 
 type ChatAdapter struct {
 	chat.Chat
-	loc *messages.Localization
+	settings *bot.UserSettings
 }
 
-func NewChatAdapter(chat chat.Chat, loc *messages.Localization) *ChatAdapter {
+func NewChatAdapter(chat chat.Chat, settings *bot.UserSettings) *ChatAdapter {
 	return &ChatAdapter{
-		Chat: chat,
-		loc:  loc,
+		Chat:     chat,
+		settings: settings,
 	}
 }
 
@@ -35,7 +36,7 @@ const (
 var ErrLocalizeMessage = errors.New("localize message error")
 
 func (ca *ChatAdapter) PrintMessage(c *chat.ChatContext, m *i18n.Message) error {
-	l := ca.loc.Localizer()
+	l := ca.settings.Loc.Localizer()
 	localized, err := l.LocalizeMessage(m)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrLocalizeMessage, err)
@@ -44,7 +45,7 @@ func (ca *ChatAdapter) PrintMessage(c *chat.ChatContext, m *i18n.Message) error 
 }
 
 func (ca *ChatAdapter) ShowMenuMessages(c *chat.ChatContext, m *i18n.Message, ops []*i18n.Message) error {
-	l := ca.loc.Localizer()
+	l := ca.settings.Loc.Localizer()
 	localized, err := messages.LocalizeMessages(l, ops)
 	if err != nil {
 		return err
@@ -62,12 +63,12 @@ func (ca *ChatAdapter) ShowAsOptions(c *chat.ChatContext, me *i18n.Message, ops 
 		return fmt.Errorf("%w: slots array too small =%d", common.ErrInvalidArgument, len(ops))
 	}
 
-	localized, err := ca.loc.Localizer().LocalizeMessage(me)
+	localized, err := ca.settings.Loc.Localizer().LocalizeMessage(me)
 	if err != nil {
 		return err
 	}
 
-	loc := ops[0].Start.Location()
+	loc := ca.settings.TimeZone
 	m := make(map[string]struct{}, len(ops))
 	for _, v := range ops {
 		t := v.Start.In(loc)

--- a/back/appointment-service/internal/bot/command/default.go
+++ b/back/appointment-service/internal/bot/command/default.go
@@ -3,11 +3,10 @@ package command
 import (
 	"scheduler/appointment-service/internal/bot"
 	"scheduler/appointment-service/internal/bot/chat"
-	"scheduler/appointment-service/internal/bot/i18n/messages"
 )
 
-func NewDefaultMainMenu(chat chat.Chat, l *messages.Localization, connection *bot.SchedulerConnection) (*MainMenu, error) {
-	md, err := NewMenuDeps(chat, l)
+func NewDefaultMainMenu(chat chat.Chat, userSettings *bot.UserSettings, connection *bot.SchedulerConnection) (*MainMenu, error) {
+	md, err := NewMenuDeps(chat, userSettings)
 	if err != nil {
 		return nil, err
 	}

--- a/back/appointment-service/internal/bot/command/dialogs_storage.go
+++ b/back/appointment-service/internal/bot/command/dialogs_storage.go
@@ -5,12 +5,14 @@ import (
 	"scheduler/appointment-service/internal/bot/chat"
 	"scheduler/appointment-service/internal/bot/i18n/messages"
 	"sync"
+	"time"
 )
 
 type DialogsStorage struct {
 	mu         sync.RWMutex
 	depsProto  *MenuDeps
 	connection *bot.SchedulerConnection
+	defaultLoc *time.Location
 	dialogs    map[Customer]*DialogValue
 }
 
@@ -19,19 +21,23 @@ type DialogValue struct {
 	Menu   *MainMenu
 }
 
-func NewDialogStorage(chat chat.Chat, l *messages.Localization, connection *bot.SchedulerConnection) (*DialogsStorage, error) {
-	deps, err := NewMenuDeps(chat, l)
+func NewDialogStorage(chat chat.Chat, l *messages.Localization, defaultTimeZone *time.Location, connection *bot.SchedulerConnection) (*DialogsStorage, error) {
+	deps, err := NewMenuDeps(chat, &bot.UserSettings{
+		Loc:      l,
+		TimeZone: defaultTimeZone,
+	})
 	if err != nil {
 		return nil, err
 	}
 	return &DialogsStorage{
 		depsProto:  deps,
 		connection: connection,
+		defaultLoc: defaultTimeZone,
 		dialogs:    make(map[Customer]*DialogValue),
 	}, nil
 }
 
-func (ds *DialogsStorage) GetOrCreateMenu(ca Customer, ch chat.ChatID) *MainMenu {
+func (ds *DialogsStorage) GetOrCreateMenu(ca Customer, ch chat.ChatID, language string, userTimeZone *time.Location) *MainMenu {
 	dialog := ds.GetDialog(ca)
 	if dialog != nil && dialog.ChatID == ch {
 		return dialog.Menu
@@ -42,6 +48,14 @@ func (ds *DialogsStorage) GetOrCreateMenu(ca Customer, ch chat.ChatID) *MainMenu
 	dialog = ds.dialogs[ca]
 	if dialog == nil || dialog.ChatID != ch {
 		clone := ds.depsProto.Clone()
+		if userTimeZone != nil {
+			clone.UserSettings.TimeZone = userTimeZone
+		} else {
+			clone.UserSettings.TimeZone = ds.defaultLoc
+		}
+		if language != "" {
+			_ = clone.SetLanguage(language)
+		}
 		appointments := &HttpAppointment{Connection: ds.connection}
 		dialog = &DialogValue{
 			Menu:   newMainMenu(clone, newDefaultSlotSelectionCommand(clone, ds.connection), appointments),

--- a/back/appointment-service/internal/bot/command/main_menu.go
+++ b/back/appointment-service/internal/bot/command/main_menu.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	common "scheduler/appointment-service/internal"
+	"scheduler/appointment-service/internal/bot"
 	"scheduler/appointment-service/internal/bot/chat"
 	"scheduler/appointment-service/internal/bot/i18n/messages"
 	"sort"
@@ -20,49 +21,53 @@ type mainMenuState uint
 const (
 	menuStart mainMenuState = iota
 	menuSlotSelection
+	menuSettings
 )
 
 type MenuDeps struct {
-	chat chat.Chat
-	Loc  *messages.Localization
-	MM   messages.MessageMap
+	chat         chat.Chat
+	UserSettings *bot.UserSettings
+	MM           messages.MessageMap
 }
 
 func (md *MenuDeps) Chat() *ChatAdapter {
-	return NewChatAdapter(md.chat, md.Loc)
+	return NewChatAdapter(md.chat, md.UserSettings)
 }
 
 func (md *MenuDeps) Clone() *MenuDeps {
-	l := *md.Loc
+	l := *md.UserSettings.Loc
 	return &MenuDeps{
 		chat: md.chat,
-		Loc:  &l,
-		MM:   md.MM,
+		UserSettings: &bot.UserSettings{
+			Loc:      &l,
+			TimeZone: md.UserSettings.TimeZone,
+		},
+		MM: md.MM,
 	}
 }
 
 // TODO LangTag . seems it need to rework
 func (md *MenuDeps) SetLanguage(l string) error {
-	if md.Loc.Language() != l {
-		m, err := commandMap(md.Loc.LocalizerFor(l))
+	if md.UserSettings.Loc.Language() != l {
+		m, err := commandMap(md.UserSettings.Loc.LocalizerFor(l))
 		if err != nil {
 			return err
 		}
 		md.MM = m
-		md.Loc.SetLanguage(l)
+		md.UserSettings.Loc.SetLanguage(l)
 	}
 	return nil
 }
 
-func NewMenuDeps(ch chat.Chat, loc *messages.Localization) (*MenuDeps, error) {
-	m, err := commandMap(loc.Localizer())
+func NewMenuDeps(ch chat.Chat, userSettings *bot.UserSettings) (*MenuDeps, error) {
+	m, err := commandMap(userSettings.Loc.Localizer())
 	if err != nil {
 		return nil, err
 	}
 	return &MenuDeps{
-			chat: ch,
-			Loc:  loc,
-			MM:   m,
+			chat:         ch,
+			UserSettings: userSettings,
+			MM:           m,
 		},
 		nil
 }
@@ -71,6 +76,9 @@ func commandMap(l *i18n.Localizer) (messages.MessageMap, error) {
 	return messages.LocalizedMessageMap(l,
 		messages.BookSlot,
 		messages.Appointments,
+		messages.Settings,
+		messages.SetLanguage,
+		messages.SetTimeZone,
 		messages.Help,
 		messages.NextWeek,
 		messages.ThisWeek,
@@ -82,6 +90,7 @@ func commandMap(l *i18n.Localizer) (messages.MessageMap, error) {
 type MainMenu struct {
 	menuDeps     *MenuDeps
 	slotCommands *SlotSelectionCommand
+	settingsMenu *SettingsMenu
 	appointments AppointmentsProvider
 	state        mainMenuState
 }
@@ -118,11 +127,30 @@ func (menu *MainMenu) Process(r *Request) error {
 			}
 			menu.state = menuSlotSelection
 		} else if c == messages.Appointments {
-			return menu.ShowAppointments(r.Ctx, r.ChatContext, common.ID(r.Customer), time.Now())
+			return menu.ShowAppointments(r.Ctx, r.ChatContext, common.ID(r.Customer), time.Now().In(menu.menuDeps.UserSettings.TimeZone))
+		} else if c == messages.Settings {
+			menu.state = menuSettings
+			return menu.settingsMenu.ShowMenu(r.ChatContext)
 		} else if c == messages.Help || r.Text == "/help" {
 			return menu.ShowHelp(r.ChatContext)
 		} else {
 			return menu.showMessageForce(r.ChatContext, messages.WrongUserInput)
+		}
+	case menuSettings:
+		result, err := menu.settingsMenu.Process(r)
+		if err != nil {
+			if errors.Is(err, ErrWrongUserInput) {
+				return menu.showMessageForce(r.ChatContext, messages.WrongUserInput)
+			}
+			return err
+		}
+		switch result {
+		case SettingsResultDone:
+			return menu.BackToStart(r.ChatContext)
+		case SettingsResultContinue:
+			return nil
+		default:
+			return common.ErrInternal
 		}
 	case menuSlotSelection:
 		result, err := menu.slotCommands.Process(r)
@@ -163,7 +191,7 @@ func (menu *MainMenu) showMessageForce(c *chat.ChatContext, msg *i18n.Message) e
 func (menu *MainMenu) BackToStart(c *chat.ChatContext) error {
 	menu.state = menuStart
 	menu.slotCommands.Cancel()
-	options := []*i18n.Message{messages.BookSlot, messages.Appointments, messages.Help, messages.Cancel}
+	options := []*i18n.Message{messages.BookSlot, messages.Appointments, messages.Settings, messages.Help, messages.Cancel}
 	err := menu.menuDeps.Chat().ShowMenuMessages(c, messages.CommandRequestMessage, options)
 	if err != nil {
 		slog.ErrorContext(c.Ctx, "mainMenu.BackToStart", "err", err.Error())
@@ -178,11 +206,11 @@ func (menu *MainMenu) ShowAppointments(ctx context.Context, c *chat.ChatContext,
 		return err
 	}
 
-	msg := formatAppointmentsMessage(menu.menuDeps.Loc.Localizer(), appointments)
+	msg := formatAppointmentsMessage(menu.menuDeps.UserSettings.Loc.Localizer(), appointments, menu.menuDeps.UserSettings.TimeZone)
 	return menu.menuDeps.Chat().PrintMessage(c, &i18n.Message{ID: "AppointmentsList", Other: msg})
 }
 
-func formatAppointmentsMessage(l *i18n.Localizer, appointments []common.Slot) string {
+func formatAppointmentsMessage(l *i18n.Localizer, appointments []common.Slot, loc *time.Location) string {
 	header, err := l.LocalizeMessage(messages.AppointmentsListHeader)
 	if err != nil {
 		header = messages.AppointmentsListHeader.Other
@@ -207,7 +235,7 @@ func formatAppointmentsMessage(l *i18n.Localizer, appointments []common.Slot) st
 	b.WriteString("\n")
 	for _, appt := range apptSorted {
 		b.WriteString("- ")
-		b.WriteString(appt.Start.Format(time.DateTime))
+		b.WriteString(appt.Start.In(loc).Format(time.DateTime))
 		b.WriteString(" (")
 		b.WriteString(appt.Dur.String())
 		b.WriteString(")\n")
@@ -219,6 +247,7 @@ func newMainMenu(md *MenuDeps, slotCommands *SlotSelectionCommand, appointments 
 	return &MainMenu{
 		menuDeps:     md,
 		slotCommands: slotCommands,
+		settingsMenu: newSettingsMenu(md),
 		appointments: appointments,
 		state:        menuStart,
 	}

--- a/back/appointment-service/internal/bot/command/main_menu.go
+++ b/back/appointment-service/internal/bot/command/main_menu.go
@@ -105,7 +105,6 @@ func (menu *MainMenu) ShowHelp(c *chat.ChatContext) error {
 
 // TODO need user time zone setting (https://github.com/LevWi/scheduler/issues/17)
 func (menu *MainMenu) Process(r *Request) error {
-	r.Text = strings.ToLower(r.Text)
 	c := menu.menuDeps.MM.IdentifyMessage(r.Text)
 
 	if r.Text == "/start" {

--- a/back/appointment-service/internal/bot/command/setting_menu.go
+++ b/back/appointment-service/internal/bot/command/setting_menu.go
@@ -1,0 +1,99 @@
+package command
+
+import (
+	"fmt"
+	"scheduler/appointment-service/internal/bot/chat"
+	"scheduler/appointment-service/internal/bot/i18n/messages"
+	"strings"
+	"time"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+)
+
+type settingsState uint
+
+const (
+	settingsStart settingsState = iota
+	settingsWaitLanguage
+	settingsWaitTimeZone
+)
+
+type SettingsMenu struct {
+	deps  *MenuDeps
+	state settingsState
+}
+
+type SettingsResult uint
+
+const (
+	SettingsResultNotSet SettingsResult = iota
+	SettingsResultContinue
+	SettingsResultDone
+)
+
+func newSettingsMenu(md *MenuDeps) *SettingsMenu {
+	return &SettingsMenu{
+		deps:  md,
+		state: settingsStart,
+	}
+}
+
+func (sm *SettingsMenu) ShowMenu(c *chat.ChatContext) error {
+	sm.state = settingsStart
+	return sm.deps.Chat().ShowMenuMessages(c, messages.SelectSettingsOptionMessage,
+		[]*i18n.Message{messages.SetLanguage, messages.SetTimeZone, messages.Cancel})
+}
+
+func (sm *SettingsMenu) Process(r *Request) (SettingsResult, error) {
+	switch sm.state {
+	case settingsStart:
+		c := sm.deps.MM.IdentifyMessage(r.Text)
+		switch c {
+		case messages.SetLanguage:
+			sm.state = settingsWaitLanguage
+			return SettingsResultContinue, sm.deps.Chat().ShowMenuMessages(r.ChatContext, messages.SelectLanguageMessage,
+				[]*i18n.Message{
+					{ID: "LangRu", Other: "ru"},
+					{ID: "LangEn", Other: "en"},
+					{ID: "LangKz", Other: "kz"},
+					messages.Cancel,
+				})
+		case messages.SetTimeZone:
+			sm.state = settingsWaitTimeZone
+			return SettingsResultContinue, sm.deps.Chat().PrintMessage(r.ChatContext, messages.EnterTimeZoneMessage)
+		case messages.Cancel:
+			sm.state = settingsStart
+			return SettingsResultDone, nil
+		default:
+			return SettingsResultNotSet, ErrWrongUserInput
+		}
+	case settingsWaitLanguage:
+		lang := strings.TrimSpace(strings.ToLower(r.Text))
+		switch lang {
+		case "ru", "en", "kz":
+			if err := sm.deps.SetLanguage(lang); err != nil {
+				return SettingsResultNotSet, err
+			}
+			sm.state = settingsStart
+			if err := sm.deps.Chat().PrintMessage(r.ChatContext, messages.LanguageUpdated); err != nil {
+				return SettingsResultNotSet, err
+			}
+			return SettingsResultContinue, sm.ShowMenu(r.ChatContext)
+		default:
+			return SettingsResultNotSet, ErrWrongUserInput
+		}
+	case settingsWaitTimeZone:
+		loc, err := time.LoadLocation(strings.TrimSpace(r.Text))
+		if err != nil {
+			return SettingsResultContinue, sm.deps.Chat().PrintMessage(r.ChatContext, messages.InvalidTimeZone)
+		}
+		sm.deps.UserSettings.TimeZone = loc
+		sm.state = settingsStart
+		if err := sm.deps.Chat().PrintMessage(r.ChatContext, messages.TimeZoneUpdated); err != nil {
+			return SettingsResultNotSet, err
+		}
+		return SettingsResultContinue, sm.ShowMenu(r.ChatContext)
+	default:
+		return SettingsResultNotSet, fmt.Errorf("unexpected settings state: %v", sm.state)
+	}
+}

--- a/back/appointment-service/internal/bot/command/slots_command.go
+++ b/back/appointment-service/internal/bot/command/slots_command.go
@@ -74,10 +74,9 @@ func (sm *SlotSelectionCommand) Process(r *Request) (SlotSelectionResult, error)
 		var slots []common.Slot
 		switch c {
 		case messages.NextWeek:
-			//TODO what time zone should be used here? Need to take on account user timezone
-			slots, err = sm.deps.Commands.WeekSlots.NextWeek(r.Ctx, r.Time)
+			slots, err = sm.deps.Commands.WeekSlots.NextWeek(r.Ctx, r.Time.In(sm.deps.MD.UserSettings.TimeZone))
 		case messages.ThisWeek:
-			slots, err = sm.deps.Commands.WeekSlots.ThisWeek(r.Ctx, r.Time)
+			slots, err = sm.deps.Commands.WeekSlots.ThisWeek(r.Ctx, r.Time.In(sm.deps.MD.UserSettings.TimeZone))
 		default:
 			err = fmt.Errorf("%w: unexpected message text ID %s (%s)", ErrWrongUserInput, c.ID, r.Text)
 		}
@@ -111,7 +110,7 @@ func (sm *SlotSelectionCommand) Process(r *Request) (SlotSelectionResult, error)
 
 			timeSrt := r.Choices[0][len(DayMarker):]
 			//TODO time zone?
-			date, err := time.Parse(time.DateOnly, timeSrt)
+			date, err := time.ParseInLocation(time.DateOnly, timeSrt, sm.deps.MD.UserSettings.TimeZone)
 			if err != nil {
 				return SlotSelectionResultNotSet, fmt.Errorf("%w: for %v", err, timeSrt)
 			}

--- a/back/appointment-service/internal/bot/config.go
+++ b/back/appointment-service/internal/bot/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // TODO For slots GET request is no auth required. So business_id used in request only here.
@@ -15,6 +16,11 @@ type SchedulerConnection struct {
 	BusinessID string `cfg:"business_id"`
 	ClientId   string `cfg:"client_id"`
 	Token      string `cfg:"token"`
+}
+
+type DefaultUserSettings struct {
+	Language string `cfg:"language"`
+	TimeZone string `cfg:"time_zone"`
 }
 
 func (s *SchedulerConnection) Validate() error {
@@ -31,6 +37,20 @@ func (s *SchedulerConnection) Validate() error {
 	}
 	if s.Token == "" {
 		return errors.New("scheduler token is not set")
+	}
+	return nil
+}
+
+func (s *DefaultUserSettings) Validate() error {
+	if s.Language == "" {
+		return errors.New("default language is not set")
+	}
+	if s.TimeZone == "" {
+		return errors.New("default time_zone is not set")
+	}
+	_, err := time.LoadLocation(s.TimeZone)
+	if err != nil {
+		return fmt.Errorf("default time_zone check error: %w", err)
 	}
 	return nil
 }

--- a/back/appointment-service/internal/bot/i18n/messages/messages.go
+++ b/back/appointment-service/internal/bot/i18n/messages/messages.go
@@ -47,6 +47,51 @@ var Appointments = &i18n.Message{
 	Other: "appointments",
 }
 
+var Settings = &i18n.Message{
+	ID:    "Settings",
+	Other: "settings",
+}
+
+var SetLanguage = &i18n.Message{
+	ID:    "SetLanguage",
+	Other: "set language",
+}
+
+var SetTimeZone = &i18n.Message{
+	ID:    "SetTimeZone",
+	Other: "set time zone",
+}
+
+var SelectLanguageMessage = &i18n.Message{
+	ID:    "SelectLanguageMessage",
+	Other: "Please select language",
+}
+
+var SelectSettingsOptionMessage = &i18n.Message{
+	ID:    "SelectSettingsOptionMessage",
+	Other: "Please select settings option",
+}
+
+var EnterTimeZoneMessage = &i18n.Message{
+	ID:    "EnterTimeZoneMessage",
+	Other: "Please type time zone (IANA), for example: Europe/Berlin",
+}
+
+var InvalidTimeZone = &i18n.Message{
+	ID:    "InvalidTimeZone",
+	Other: "Invalid time zone",
+}
+
+var LanguageUpdated = &i18n.Message{
+	ID:    "LanguageUpdated",
+	Other: "Language updated",
+}
+
+var TimeZoneUpdated = &i18n.Message{
+	ID:    "TimeZoneUpdated",
+	Other: "Time zone updated",
+}
+
 var AppointmentsListHeader = &i18n.Message{
 	ID:    "AppointmentsListHeader",
 	Other: "Your upcoming appointments:",
@@ -78,6 +123,7 @@ var HelpMessage = &i18n.Message{
 "help" - Show this help message
 "book a slot"   - Book a slot for an appointment
 "appointments" - Show your upcoming appointments
+"settings" - Open language and time zone settings
 "cancel" - Cancel current operation or booking
 Use special button or type it
 `,

--- a/back/appointment-service/internal/bot/i18n/messages/messages.go
+++ b/back/appointment-service/internal/bot/i18n/messages/messages.go
@@ -145,7 +145,7 @@ type MessageConstant = i18n.Message
 type MessageMap map[string]*MessageConstant
 
 func (m MessageMap) IdentifyMessage(s string) *MessageConstant {
-	return m[s]
+	return m[strings.ToLower(s)]
 }
 
 func LocalizedMessageMap(l *i18n.Localizer, ms ...*i18n.Message) (MessageMap, error) {

--- a/back/appointment-service/internal/bot/user_settings.go
+++ b/back/appointment-service/internal/bot/user_settings.go
@@ -1,0 +1,11 @@
+package bot
+
+import (
+	"scheduler/appointment-service/internal/bot/i18n/messages"
+	"time"
+)
+
+type UserSettings struct {
+	Loc      *messages.Localization
+	TimeZone *time.Location
+}


### PR DESCRIPTION
### Motivation
- Provide per-user localization and time zone handling for the bot so users see times and messages in their preferred language and timezone.
- Allow configuring a server-wide default language and timezone and fall back to it for new dialogs.
- Expose an interactive Settings menu to let users change language and timezone at runtime.

### Description
- Added `DefaultUserSettings` to bot config and validated it in `LoadBotConfig`, and load default location with `time.LoadLocation` in `main.go` to pass to dialog storage via `NewDialogStorage`.
- Introduced `UserSettings` (holds `Loc` and `TimeZone`) and threaded it through `MenuDeps`, `ChatAdapter`, and `DialogsStorage` so menus and message formatting use the user locale and timezone instead of global defaults.
- Implemented a `SettingsMenu` with flows to `SetLanguage` and `SetTimeZone`, and added a `Settings` option to the main menu; added `telegramLanguage` helper to extract a 2-letter language code from Telegram user info.
- Updated i18n constants with new messages for settings flow, updated appointment and slots formatting and processing to use `UserSettings.TimeZone`, and updated slot date parsing to use `time.ParseInLocation`.

### Testing
- Built the project with `go build ./...` which completed successfully on the modified codebase.
- No new automated unit tests were added in this change and existing test suite was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8eb21458c832baeee263e4970c1ff)