### PR TITLE
Add DST-aware tests for ChatAdapter.ShowAsOptions

### DIFF
--- a/back/appointment-service/internal/bot/command/chat_adapter_test.go
+++ b/back/appointment-service/internal/bot/command/chat_adapter_test.go
@@ -1,0 +1,106 @@
+package command
+
+import (
+	"context"
+	"strings"
+	common "scheduler/appointment-service/internal"
+	"scheduler/appointment-service/internal/bot"
+	"scheduler/appointment-service/internal/bot/chat"
+	"scheduler/appointment-service/internal/bot/i18n/messages"
+	"testing"
+	"time"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/text/language"
+)
+
+type stubChat struct {
+	showOptionsMessage string
+	showOptions        []chat.ChatOption
+}
+
+func (s *stubChat) Print(_ *chat.ChatContext, _ string) error { return nil }
+
+func (s *stubChat) ShowOptions(_ *chat.ChatContext, message string, m []chat.ChatOption) error {
+	s.showOptionsMessage = message
+	s.showOptions = m
+	return nil
+}
+
+func (s *stubChat) ShowMenu(_ *chat.ChatContext, _ string, _ []string) error { return nil }
+
+func (s *stubChat) HideMenu(_ *chat.ChatContext) error { return nil }
+
+func testLocalization() *messages.Localization {
+	bundle := i18n.NewBundle(language.English)
+	bundle.AddMessages(language.English, messages.SelectRequestMessage, messages.DialogTimeZone)
+	return messages.NewLocalization(bundle, "en")
+}
+
+func TestChatAdapter_ShowAsOptions_AppendsGMTWhenOffsetsAreSame(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cha := &stubChat{}
+	adapter := NewChatAdapter(cha, &bot.UserSettings{Loc: testLocalization(), TimeZone: loc})
+
+	ops := []LabeledSlot{
+		{ID: 1, Slot: common.Slot{Start: time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+		{ID: 2, Slot: common.Slot{Start: time.Date(2026, time.April, 13, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+		{ID: 3, Slot: common.Slot{Start: time.Date(2026, time.April, 20, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+	}
+
+	err = adapter.ShowAsOptions(&chat.ChatContext{Ctx: context.Background(), ChatID: "c1"}, messages.SelectRequestMessage, ops)
+	if err != nil {
+		t.Fatalf("ShowAsOptions() error = %v", err)
+	}
+
+	if !strings.Contains(cha.showOptionsMessage, "Time zone: Europe/Berlin (GMT+02:00)") {
+		t.Fatalf("expected GMT offset in message, got: %q", cha.showOptionsMessage)
+	}
+
+	if len(cha.showOptions) != 3 {
+		t.Fatalf("expected 3 day options, got %d", len(cha.showOptions))
+	}
+
+	for _, option := range cha.showOptions {
+		if !strings.HasPrefix(option.ID, DayMarker) {
+			t.Fatalf("expected day marker option id, got: %q", option.ID)
+		}
+	}
+}
+
+func TestChatAdapter_ShowAsOptions_OmitsGMTWhenOffsetsDiffer(t *testing.T) {
+	loc, err := time.LoadLocation("Europe/Berlin")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cha := &stubChat{}
+	adapter := NewChatAdapter(cha, &bot.UserSettings{Loc: testLocalization(), TimeZone: loc})
+
+	ops := []LabeledSlot{
+		{ID: 1, Slot: common.Slot{Start: time.Date(2026, time.March, 23, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+		{ID: 2, Slot: common.Slot{Start: time.Date(2026, time.March, 30, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+		{ID: 3, Slot: common.Slot{Start: time.Date(2026, time.April, 6, 10, 0, 0, 0, time.UTC), Dur: 30 * time.Minute}},
+	}
+
+	err = adapter.ShowAsOptions(&chat.ChatContext{Ctx: context.Background(), ChatID: "c1"}, messages.SelectRequestMessage, ops)
+	if err != nil {
+		t.Fatalf("ShowAsOptions() error = %v", err)
+	}
+
+	if strings.Contains(cha.showOptionsMessage, "(GMT") {
+		t.Fatalf("did not expect GMT offset in message, got: %q", cha.showOptionsMessage)
+	}
+
+	if !strings.Contains(cha.showOptionsMessage, "Time zone: Europe/Berlin") {
+		t.Fatalf("expected time zone line in message, got: %q", cha.showOptionsMessage)
+	}
+
+	if len(cha.showOptions) != 3 {
+		t.Fatalf("expected 3 day options, got %d", len(cha.showOptions))
+	}
+}

--- a/back/appointment-service/internal/bot/command/chat_adapter_test.go
+++ b/back/appointment-service/internal/bot/command/chat_adapter_test.go
@@ -2,11 +2,11 @@ package command
 
 import (
 	"context"
-	"strings"
 	common "scheduler/appointment-service/internal"
 	"scheduler/appointment-service/internal/bot"
 	"scheduler/appointment-service/internal/bot/chat"
 	"scheduler/appointment-service/internal/bot/i18n/messages"
+	"strings"
 	"testing"
 	"time"
 
@@ -92,7 +92,7 @@ func TestChatAdapter_ShowAsOptions_OmitsGMTWhenOffsetsDiffer(t *testing.T) {
 		t.Fatalf("ShowAsOptions() error = %v", err)
 	}
 
-	if strings.Contains(cha.showOptionsMessage, "(GMT") {
+	if strings.Contains(cha.showOptionsMessage, "GMT") {
 		t.Fatalf("did not expect GMT offset in message, got: %q", cha.showOptionsMessage)
 	}
 


### PR DESCRIPTION
### Motivation
- Ensure `ChatAdapter.ShowAsOptions` correctly includes a GMT offset when all slots share the same timezone offset across a 3-week range and omits the GMT suffix when offsets differ (e.g., across a DST transition). 

### Description
- Add `back/appointment-service/internal/bot/command/chat_adapter_test.go` containing a lightweight `stubChat`, `testLocalization()` helper, and two tests that exercise DST-dependent formatting for `ShowAsOptions`. 
- `TestChatAdapter_ShowAsOptions_AppendsGMTWhenOffsetsAreSame` verifies GMT suffix is appended when three weekly slots (2026-04-06, 2026-04-13, 2026-04-20) all map to the same offset for `Europe/Berlin` and that day options are emitted. 
- `TestChatAdapter_ShowAsOptions_OmitsGMTWhenOffsetsDiffer` verifies the GMT suffix is omitted when a 3-week slot range spans a DST offset change (2026-03-23, 2026-03-30, 2026-04-06) and that day options are emitted. 

### Testing
- Ran `go test ./internal/bot/command` from `back/appointment-service` and the package tests passed successfully. 
- Attempting `go test ./back/appointment-service/internal/bot/command` from the repository root failed due to the repository not being a Go module (error advising to run `go mod init`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf84b2c08832bb34401facf0d8c5a)